### PR TITLE
Initial port to 1.0 erlang+otp gleam libs

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -8,8 +8,8 @@ gleam = ">= 1.11.0"
 
 [dependencies]
 gleam_stdlib = ">= 0.58.0 and < 0.61.0"
-gleam_erlang = "~> 0.25"
-gleam_otp = "~> 0.10"
+gleam_erlang = ">= 1.2.0 and < 2.0.0"
+gleam_otp = "== 1.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
-  { name = "gleam_otp", version = "0.16.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "50DA1539FC8E8FA09924EB36A67A2BBB0AD6B27BCDED5A7EF627057CF69D035E" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_otp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "7020E652D18F9ABAC9C877270B14160519FA0856EE80126231C505D719AD68DA" },
   { name = "gleam_stdlib", version = "0.60.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "621D600BB134BC239CB2537630899817B1A42E60A1D46C5E9F3FAE39F88C800B" },
   { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
 ]
 
 [requirements]
-gleam_erlang = { version = "~> 0.25" }
-gleam_otp = { version = "~> 0.10" }
+gleam_erlang = { version = ">= 1.2.0 and < 2.0.0" }
+gleam_otp = { version = "== 1.0.0" }
 gleam_stdlib = { version = ">= 0.58.0 and < 0.61.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/singularity.gleam
+++ b/src/singularity.gleam
@@ -41,9 +41,6 @@
 
 import gleam/bool
 import gleam/dict.{type Dict}
-import gleam/dynamic
-import gleam/dynamic/decode.{type Decoder}
-import gleam/erlang/atom.{type Atom}
 import gleam/erlang/process.{type Monitor, type Pid, type Selector, type Subject}
 import gleam/int
 import gleam/option.{type Option, None, Some}
@@ -378,27 +375,15 @@ fn get_with_retry(
   actor.continue(state)
 }
 
-/// Extracts the name of this variant from the caller's actor wrapper.
-///
-fn get_act_variant_name(wrapped: wrap) -> String {
-  let assert Ok(atom) =
-    wrapped
-    |> dynamic.from
-    |> decode.run(atom_decoder())
-
-  atom.to_string(atom)
-}
-
-fn atom_decoder() -> Decoder(Atom) {
-  use atom <- decode.field(0, atom.decoder())
-
-  decode.success(atom)
-}
-
 /// Extracts the name of this variant from the constructor.
 ///
 @external(erlang, "singularity_ffi", "cons_variant_name")
 fn cons_variant_name(varfn: fn(Subject(msg)) -> wrap) -> String
+
+/// Extracts the name of this variant from the caller's actor wrapper.
+///
+@external(erlang, "singularity_ffi", "get_act_variant_name")
+fn get_act_variant_name(wrapped: wrap) -> String
 
 /// Returns the current OS system time.
 ///

--- a/src/singularity_ffi.erl
+++ b/src/singularity_ffi.erl
@@ -1,7 +1,10 @@
 -module(singularity_ffi).
 
--export([cons_variant_name/1]).
+-export([cons_variant_name/1, get_act_variant_name/1]).
 
 cons_variant_name(Varfn) ->
-  {Name, {_, _}} = Varfn({nil, nil}),
+  get_act_variant_name(Varfn({nil, nil})).
+
+get_act_variant_name(Wrapped) ->
+  {Name, _} = Wrapped,
   atom_to_binary(Name).


### PR DESCRIPTION
Port singularity to the 1.0 versions of gleam_erlang and gleam_otp.

Removes use of some deprecated APIs, but there are a couple more cleanups to do in a subsequent PR.